### PR TITLE
Remove trusted.gpg.d artifacts

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -31,6 +31,19 @@
     state: present
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')
 
+- name: Ensure apt key is not present in trusted.gpg.d
+  ansible.builtin.file:
+    path: /etc/apt/trusted.gpg.d/docker.asc
+    state: absent
+
+- name: Ensure the repo referencing the previous trusted.gpg.d key is not present
+  apt_repository:
+    repo: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+    state: absent
+    filename: "{{ docker_apt_filename }}"
+    update_cache: true
+  when: docker_add_repo | bool
+
 - name: Ensure directory exists for /etc/apt/keyrings
   file:
     path: /etc/apt/keyrings


### PR DESCRIPTION
https://github.com/geerlingguy/ansible-role-docker/pull/436 introduced a change to the path where the apt key was placed, and to the associated repository listing in /etc/apt/sources.d/docker.list. We've just run into a problem with this approach, as detailed in the issue I raised, https://github.com/geerlingguy/ansible-role-docker/issues/460.